### PR TITLE
[TASK] Use port-parameter in mysqli_connect

### DIFF
--- a/src/Utility/DatabaseUtility.php
+++ b/src/Utility/DatabaseUtility.php
@@ -15,7 +15,7 @@ class DatabaseUtility
      */
     public function getTables($dbConf)
     {
-        $link = mysqli_connect($dbConf['host'], $dbConf['user'], $dbConf['password'], $dbConf['dbname']);
+        $link = mysqli_connect($dbConf['host'], $dbConf['user'], $dbConf['password'], $dbConf['dbname'], $dbConf['port']);
         $result = $link->query('SHOW TABLES');
         $allTables = [];
         while ($row = $result->fetch_row()) {


### PR DESCRIPTION
DB-port is configurable through arguments and should be used for the connection as well.

Currently port is not used in connection which might lead to an error if db is only reachable through non-default port which might be configured before.

closes #15 