### PR TITLE
[BUGFIX] db:export not using latest release

### DIFF
--- a/deployer/db/task/db_backup.php
+++ b/deployer/db/task/db_backup.php
@@ -22,7 +22,7 @@ task('db:backup', function () {
     ];
 
     if (get('is_argument_host_the_same_as_local_host')) {
-        if (testLocally('cd {{deploy_path}} && [ -d .dep/releases ]')) {
+        if (testLocally('cd {{deploy_path}} && [ -f .dep/latest_release ]')) {
             $latestRelease = (int)runLocally('cd {{deploy_path}} && cat .dep/latest_release || echo 0');
             $tags = $optionUtility->getOption('tags', false);
             if ($latestRelease > 0) {


### PR DESCRIPTION
This PR fixes the bash check for the latest `.dep/latest_release` file.