### PR TITLE
feat: Add dbCodeFilter option to filter databases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -590,6 +590,10 @@ Example output files located in folder {{deploy_path}}/.dep/databases/dumps/:
    2025-02-26_14:56:08#server=live#dbcode=database_default#type=data#dumpcode=362d7ca0ff065f489c9b79d0a73720f5.sql
    2025-02-26_14:56:08#server=live#dbcode=database_default#type=structure#dumpcode=362d7ca0ff065f489c9b79d0a73720f5.sql
 
+Example, if you want to export only some databases :
+::
+
+   dep db:export live --options=dbCodeFilter:db1+db2
 
 db:import
 +++++++++
@@ -602,6 +606,10 @@ on target instance. There is required option ``--options=dumpcode:[value]`` to b
 
    dep db:import dev --options=dumpcode:0772a8d396911951022db5ea385535f66
 
+Example, if you want to import only some databases :
+::
+
+   dep db:import live --options=dbCodeFilter:db1+db2
 
 
 db:process
@@ -639,6 +647,9 @@ without getting it again and again from remote host.
    # import from database storage of current host
    dep db:pull live --options=fromLocalStorage
 
+   # export and import only some databases
+   dep db:pull live --options=dbCodeFilter:db1+db2
+
 db:push
 +++++++
 
@@ -662,6 +673,9 @@ You can also forbid push to live instance by setting ``db_allow_push_live`` to `
 ::
 
    dep db:push live
+
+   # Only push some databases
+   dep db:push live --options=dbCodeFilter:db1+db2
 
 db:rmdump
 +++++++++

--- a/deployer/db/task/db_export.php
+++ b/deployer/db/task/db_export.php
@@ -23,6 +23,12 @@ task('db:export', function () {
 
     if (get('is_argument_host_the_same_as_local_host')) {
         foreach (get('db_databases_merged') as $databaseCode => $databaseConfig) {
+            if ($optionUtility->getOption('dbCodeFilter')) {
+                if (!in_array($databaseCode, $optionUtility->getOption('dbCodeFilter'), true)) {
+                    continue;
+                }
+            }
+
             $filenameParts = [
                 'dateTime' => date('Y-m-d_H-i-s'),
                 'server' => 'server=' . $fileUtility->normalizeFilename(get('local_host')),

--- a/deployer/db/task/db_import.php
+++ b/deployer/db/task/db_import.php
@@ -19,6 +19,12 @@ task('db:import', function () {
     if (get('is_argument_host_the_same_as_local_host')) {
         $databaseStoragePathLocal = get('db_storage_path_local');
         foreach (get('db_databases_merged') as $databaseCode => $databaseConfig) {
+            if ($optionUtility->getOption('dbCodeFilter')) {
+                if (!in_array($databaseCode, $optionUtility->getOption('dbCodeFilter'), true)) {
+                    continue;
+                }
+            }
+
             $globStart = $databaseStoragePathLocal
                 . '*dbcode=' . $fileUtility->normalizeFilename($databaseCode)
                 . '*dumpcode=' . $dumpCode;

--- a/deployer/db/task/db_truncate.php
+++ b/deployer/db/task/db_truncate.php
@@ -6,6 +6,7 @@ use Deployer\Exception\GracefulShutdownException;
 use SourceBroker\DeployerExtendedDatabase\Utility\ArrayUtility;
 use SourceBroker\DeployerExtendedDatabase\Utility\DatabaseUtility;
 use SourceBroker\DeployerExtendedDatabase\Utility\ConsoleUtility;
+use SourceBroker\DeployerExtendedDatabase\Utility\OptionUtility;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /*
@@ -14,8 +15,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 task('db:truncate', function () {
     $arrayUtility = new ArrayUtility();
     $databaseUtility = new DatabaseUtility();
+    $optionUtility = new OptionUtility(input()->getOption('options'));
+
     if (get('is_argument_host_the_same_as_local_host')) {
-        foreach (get('db_databases_merged') as $databaseConfig) {
+        foreach (get('db_databases_merged') as $databaseCode => $databaseConfig) {
+            if ($optionUtility->getOption('dbCodeFilter')) {
+                if (!in_array($databaseCode, $optionUtility->getOption('dbCodeFilter'), true)) {
+                    continue;
+                }
+            }
+
             if (isset($databaseConfig['truncate_tables']) && is_array($databaseConfig['truncate_tables'])) {
                 $truncateTables = $arrayUtility->filterWithRegexp(
                     $databaseConfig['truncate_tables'],

--- a/src/Utility/OptionUtility.php
+++ b/src/Utility/OptionUtility.php
@@ -9,6 +9,7 @@ class OptionUtility
 {
     public const AVAILABLE_OPTIONS = [
         'dumpcode',
+        'dbCodeFilter',
         'tags',
         'target',
         'fromLocalStorage',
@@ -20,6 +21,7 @@ class OptionUtility
 
     public const ARRAY_OPTIONS = [
         'tags',
+        'dbCodeFilter'
     ];
 
     private $options = [];


### PR DESCRIPTION
This PR adds a dbCodeFilter option which allows to filter the database impacted by import/export/truncate operations. 

## Example usage 

```
   dep db:export live --options=dbCodeFilter:db1+db2
   dep db:push live --options=dbCodeFilter:db3
```

## Use case
 
We have multiple databases which have different purposes and size. For development purposes it's sometimes important for us to only import / modify / export a certain database. 

## What's next ?

I'm open to ideas on improving this PR and the documentation attached to it, please feel free to send any feedback my way ! 