### PR TITLE
[BUGFIX] SSL options in db:import

### DIFF
--- a/deployer/db/task/db_import.php
+++ b/deployer/db/task/db_import.php
@@ -85,10 +85,11 @@ task('db:import', function () {
                 ));
                 // Import dump with data.
                 runLocally(sprintf(
-                    '%s --defaults-file=%s %s -D%s -e%s',
+                    '%s --defaults-file=%s %s %s -D%s -e%s',
                     get('local/bin/mysql'),
                     escapeshellarg($tmpMyCnfFile),
                     get('db_import_mysql_options_data', ''),
+                    DatabaseUtility::getSslCliOptions($databaseConfig),
                     escapeshellarg($databaseConfig['dbname']),
                     escapeshellarg('SOURCE ' . $dataSqlFile[0])
                 ));

--- a/deployer/db/task/db_import.php
+++ b/deployer/db/task/db_import.php
@@ -94,7 +94,7 @@ task('db:import', function () {
                     escapeshellarg('SOURCE ' . $dataSqlFile[0])
                 ));
                 $postSqlInCollected = [];
-                if (isset($databaseConfig['post_sql_in_markers'])) {
+                if ($databaseConfig['post_sql_in_markers'] ?? false) {
                     // Prepare some markers to use in post_sql_in_markers:
                     $markersArray = [];
                     if (!empty(get('public_urls', []))) {
@@ -125,7 +125,7 @@ task('db:import', function () {
                         $databaseConfig['post_sql_in_markers']
                     );
                 }
-                if (isset($databaseConfig['post_sql_in'])) {
+                if ($databaseConfig['post_sql_in'] ?? false) {
                     $postSqlInCollected[] = $databaseConfig['post_sql_in'];
                 }
                 if (!empty($postSqlInCollected)) {

--- a/deployer/db/task/db_import.php
+++ b/deployer/db/task/db_import.php
@@ -61,16 +61,16 @@ task('db:import', function () {
                 // Drop all tables.
                 if (empty($optionUtility->getOption('importTaskDoNotDropAllTablesBeforeImport'))) {
                     runLocally(sprintf(
-                        '%s --defaults-file=%s %s --add-drop-table --no-data | ' .
-                        'grep -e \'^DROP \| FOREIGN_KEY_CHECKS\' | %s --defaults-file=%s %s -D%s %s',
+                        '%s --defaults-file=%s %s %s --add-drop-table --no-data | ' .
+                        'grep -e \'^DROP \| FOREIGN_KEY_CHECKS\' | %s %s --defaults-file=%s %s -D%s',
                         get('local/bin/mysqldump'),
                         escapeshellarg($tmpMyCnfFile),
+                        DatabaseUtility::getSslCliOptions($databaseConfig),
                         escapeshellarg($databaseConfig['dbname']),
                         get('local/bin/mysql'),
                         escapeshellarg($tmpMyCnfFile),
                         DatabaseUtility::getSslCliOptions($databaseConfig),
-                        escapeshellarg($databaseConfig['dbname']),
-                        DatabaseUtility::getSslCliOptions($databaseConfig)
+                        escapeshellarg($databaseConfig['dbname'])
                     ));
                 }
                 // Import dump with database structure.

--- a/deployer/db/task/db_import.php
+++ b/deployer/db/task/db_import.php
@@ -62,7 +62,7 @@ task('db:import', function () {
                 if (empty($optionUtility->getOption('importTaskDoNotDropAllTablesBeforeImport'))) {
                     runLocally(sprintf(
                         '%s --defaults-file=%s %s %s --add-drop-table --no-data | ' .
-                        'grep -e \'^DROP \| FOREIGN_KEY_CHECKS\' | %s %s --defaults-file=%s %s -D%s',
+                        'grep -e \'^DROP \| FOREIGN_KEY_CHECKS\' | %s --defaults-file=%s %s -D%s',
                         get('local/bin/mysqldump'),
                         escapeshellarg($tmpMyCnfFile),
                         DatabaseUtility::getSslCliOptions($databaseConfig),

--- a/deployer/db/task/db_import.php
+++ b/deployer/db/task/db_import.php
@@ -132,10 +132,11 @@ task('db:import', function () {
                     $importSqlFile = $databaseStoragePathLocal . $dumpCode . '.sql';
                     file_put_contents($importSqlFile, implode(' ', $postSqlInCollected));
                     runLocally(sprintf(
-                        ' %s --defaults-file=%s %s -D%s -e%s',
+                        ' %s --defaults-file=%s %s %s -D%s -e%s',
                         get('local/bin/mysql'),
                         escapeshellarg($tmpMyCnfFile),
                         get('db_import_mysql_options_post_sql_in', ''),
+                        DatabaseUtility::getSslCliOptions($databaseConfig),
                         escapeshellarg($databaseConfig['dbname']),
                         escapeshellarg('SOURCE ' . $importSqlFile)
                     ));


### PR DESCRIPTION
This PR fixes missing SSL options during database import + resolves an issue where empty values for `post_sql_in_markers` and `post_sql_in` lead to an unwanted database command execution.